### PR TITLE
update pw dialogs

### DIFF
--- a/src/qt/dbb_gui.cpp
+++ b/src/qt/dbb_gui.cpp
@@ -343,7 +343,7 @@ DBBDaemonGui::DBBDaemonGui(QWidget* parent) : QMainWindow(parent),
     connect(this->ui->passwordLineEdit, SIGNAL(returnPressed()), this, SLOT(passwordProvided()));
 
     //set password screen
-    connect(this->ui->modalBlockerView, SIGNAL(newPasswordAvailable(const QString&, bool)), this, SLOT(setPasswordProvided(const QString&, bool)));
+    connect(this->ui->modalBlockerView, SIGNAL(newPasswordAvailable(const QString&, const QString&, bool)), this, SLOT(setPasswordProvided(const QString&, const QString&, bool)));
     connect(this->ui->modalBlockerView, SIGNAL(signingShouldProceed(const QString&, void *, const UniValue&, int)), this, SLOT(proceedVerification(const QString&, void *, const UniValue&, int)));
     //modal general signals
     connect(this->ui->modalBlockerView, SIGNAL(modalViewWillShowHide(bool)), this, SLOT(modalStateChanged(bool)));
@@ -773,16 +773,30 @@ void DBBDaemonGui::hideSessionPasswordView()
     animation->start(QAbstractAnimation::DeleteWhenStopped);
 }
 
-void DBBDaemonGui::showSetPasswordInfo(bool showCleanInfo)
+void DBBDaemonGui::showSetPasswordInfo(bool newWallet)
 {
-    ui->modalBlockerView->showSetPasswordInfo(showCleanInfo);
+    ui->modalBlockerView->showSetPasswordInfo(newWallet);
 }
 
-void DBBDaemonGui::setPasswordProvided(const QString& newPassword, bool tbiRequired)
+void DBBDaemonGui::setPasswordProvided(const QString& newPassword, const QString& extraInput, bool newWallet)
 {
+    dbb_process_infolayer_style_t process; 
+    std::string command = "{\"password\" : \"" + newPassword.toStdString() + "\"}";
+    
+    if (newWallet) {
+        deviceName = extraInput;
+        process = DBB_PROCESS_INFOLAYER_STYLE_NO_INFO;
+    } else {
+        if (extraInput.toStdString() != sessionPassword) {
+            showModalInfo(tr("Incorrect old password"), DBB_PROCESS_INFOLAYER_CONFIRM_WITH_BUTTON);
+            return;
+        }
+        process = DBB_PROCESS_INFOLAYER_STYLE_TOUCHBUTTON;
+    }
+
     showModalInfo(tr("Saving Password"));
 
-    if (executeCommandWrapper("{\"password\" : \"" + newPassword.toStdString() + "\"}", tbiRequired ? DBB_PROCESS_INFOLAYER_STYLE_TOUCHBUTTON : DBB_PROCESS_INFOLAYER_STYLE_NO_INFO, [this](const std::string& cmdOut, dbb_cmd_execution_status_t status) {
+    if (executeCommandWrapper(command, process, [this](const std::string& cmdOut, dbb_cmd_execution_status_t status) {
         UniValue jsonOut;
         jsonOut.read(cmdOut);
         emit gotResponse(jsonOut, status, DBB_RESPONSE_TYPE_PASSWORD);
@@ -1141,22 +1155,27 @@ void DBBDaemonGui::upgradeFirmwareDone(bool status)
 void DBBDaemonGui::setDeviceNameClicked()
 {
     bool ok;
-    QString newName = QInputDialog::getText(this, "", tr("Enter device name"), QLineEdit::Normal, "", &ok);
-    if (!ok || newName.isEmpty())
+    deviceName = QInputDialog::getText(this, "", tr("Enter device name"), QLineEdit::Normal, "", &ok);
+    if (!ok || deviceName.isEmpty())
         return;
 
-    QRegExp nameMatcher("^[0-9A-Z-_]{4,20}$", Qt::CaseInsensitive);
-    if (!nameMatcher.exactMatch(newName))
+    QRegExp nameMatcher("^[0-9A-Z-_]{1,64}$", Qt::CaseInsensitive);
+    if (!nameMatcher.exactMatch(deviceName))
     {
         showModalInfo(tr("The device name must only contain alphanumeric characters and - or _"), DBB_PROCESS_INFOLAYER_CONFIRM_WITH_BUTTON);
         return;
     }
 
-    std::string command = "{\"name\" : \""+newName.toStdString()+"\" }";
-    executeCommandWrapper(command, DBB_PROCESS_INFOLAYER_STYLE_NO_INFO, [this](const std::string& cmdOut, dbb_cmd_execution_status_t status) {
+    setDeviceName(DBB_RESPONSE_TYPE_SET_DEVICE_NAME);
+}
+
+void DBBDaemonGui::setDeviceName(dbb_response_type_t response_type)
+{
+    std::string command = "{\"name\" : \""+deviceName.toStdString()+"\" }";
+    executeCommandWrapper(command, DBB_PROCESS_INFOLAYER_STYLE_NO_INFO, [this, response_type](const std::string& cmdOut, dbb_cmd_execution_status_t status) {
         UniValue jsonOut;
         jsonOut.read(cmdOut);
-        emit gotResponse(jsonOut, status, DBB_RESPONSE_TYPE_SET_DEVICE_NAME);
+        emit gotResponse(jsonOut, status, response_type);
     });
 }
 
@@ -1620,10 +1639,13 @@ void DBBDaemonGui::parseResponse(const UniValue& response, dbb_cmd_execution_sta
         else if (tag == DBB_RESPONSE_TYPE_BOOTLOADER_LOCK) {
             hideModalInfo();
         }
-        else if (tag == DBB_RESPONSE_TYPE_SET_DEVICE_NAME) {
+        else if (tag == DBB_RESPONSE_TYPE_SET_DEVICE_NAME || tag == DBB_RESPONSE_TYPE_SET_DEVICE_NAME_CREATE) {
             UniValue name = find_value(response, "name");
-            if (name.isStr())
+            if (name.isStr()) {
                 this->ui->deviceNameLabel->setText(QString::fromStdString(name.get_str()));
+                if (tag == DBB_RESPONSE_TYPE_SET_DEVICE_NAME_CREATE)
+                    getInfo();
+            }
         }
         else {
         }
@@ -1694,7 +1716,7 @@ void DBBDaemonGui::parseResponse(const UniValue& response, dbb_cmd_execution_sta
                 sessionPasswordDuringChangeProcess.clear();
                 cleanseLoginAndSetPassword(); //remove text from set password fields
                 //could not decrypt, password was changed successfully
-                getInfo();
+                setDeviceName(DBB_RESPONSE_TYPE_SET_DEVICE_NAME_CREATE);
             } else {
                 QString errorString;
                 UniValue touchbuttonObj = find_value(response, "touchbutton");

--- a/src/qt/dbb_gui.h
+++ b/src/qt/dbb_gui.h
@@ -68,6 +68,7 @@ typedef enum DBB_RESPONSE_TYPE {
     DBB_RESPONSE_TYPE_BOOTLOADER_UNLOCK,
     DBB_RESPONSE_TYPE_BOOTLOADER_LOCK,
     DBB_RESPONSE_TYPE_SET_DEVICE_NAME,
+    DBB_RESPONSE_TYPE_SET_DEVICE_NAME_CREATE,
 } dbb_response_type_t;
 
 typedef enum DBB_ADDRESS_STYLE {
@@ -166,6 +167,7 @@ private:
     QPropertyAnimation* netActivityAnimation;
     QPropertyAnimation* usbActivityAnimation;
     QPropertyAnimation* verificationActivityAnimation;
+    QString deviceName;
     std::string sessionPassword;                    //TODO: needs secure space / mem locking
     std::string sessionPasswordDuringChangeProcess; //TODO: needs secure space / mem locking
     std::vector<DBBWallet*> vMultisigWallets;       //!<immutable pointers to the multisig wallet objects (currently only 1)
@@ -259,9 +261,9 @@ private slots:
     void hideModalInfo();
     void modalStateChanged(bool state);
     //!show set passworf form
-    void showSetPasswordInfo(bool showCleanInfo = false);
-    //!gets called when the user hits enter (or presses button) in the "set password form"
-    void setPasswordProvided(const QString& newPassword, bool tbiRequired = false);
+    void showSetPasswordInfo(bool newWallet = false);
+    //!gets called when the user presses button in the "set password form"
+    void setPasswordProvided(const QString& newPassword, const QString& extraInput, bool newWallet = false);
     void cleanseLoginAndSetPassword();
 
     //== DBB USB ==
@@ -290,6 +292,7 @@ private slots:
     void upgradeFirmwareDone(bool state);
     //!change device name
     void setDeviceNameClicked();
+    void setDeviceName(dbb_response_type_t response_type);
 
     //== ADDRESS EXPORTING ==
     void showGetAddressDialog();

--- a/src/qt/modalview.cpp
+++ b/src/qt/modalview.cpp
@@ -13,10 +13,15 @@ ModalView::ModalView(QWidget* parent) : QWidget(parent), ui(new Ui::ModalView), 
 {
     ui->setupUi(this);
 
+    connect(this->ui->setDeviceName, SIGNAL(returnPressed()), this->ui->setPassword0, SLOT(setFocus()));
+    connect(this->ui->setPasswordOld, SIGNAL(returnPressed()), this->ui->setPassword0, SLOT(setFocus()));
     connect(this->ui->setPassword0, SIGNAL(returnPressed()), this->ui->setPassword1, SLOT(setFocus()));
+    connect(this->ui->setPassword1, SIGNAL(returnPressed()), this->ui->setPassword, SLOT(setFocus()));
+    
+    connect(this->ui->setDeviceName, SIGNAL(textChanged(const QString&)), this, SLOT(passwordCheck(const QString&)));
     connect(this->ui->setPassword0, SIGNAL(textChanged(const QString&)), this, SLOT(passwordCheck(const QString&)));
     connect(this->ui->setPassword1, SIGNAL(textChanged(const QString&)), this, SLOT(passwordCheck(const QString&)));
-    connect(this->ui->setPassword1, SIGNAL(returnPressed()), this->ui->setPassword, SIGNAL(clicked()));
+    
     connect(this->ui->setPassword, SIGNAL(clicked()), this, SLOT(setPasswordProvided()));
     connect(this->ui->cancelSetPassword, SIGNAL(clicked()), this, SLOT(cancelSetPasswordProvided()));
 
@@ -43,22 +48,21 @@ void ModalView::setText(const QString& text)
 
 void ModalView::cleanse()
 {
+    ui->setDeviceName->clear();
+    ui->setPasswordOld->clear();
     ui->setPassword0->clear();
     ui->setPassword1->clear();
 }
 
 void ModalView::setPasswordProvided()
 {
-    if (ui->setPassword0->text() != ui->setPassword1->text())
-    {
-        //: translation: password not identical text
-        // showAlert(tr("Error"), tr("Passwords not identical"));
-        //TODO
-        return;
-    }
+    if (ui->setDeviceName->isVisible())
+        emit newPasswordAvailable(ui->setPassword0->text(), ui->setDeviceName->text(), true);
+    else
+        emit newPasswordAvailable(ui->setPassword0->text(), ui->setPasswordOld->text(), false);
 
-    emit newPasswordAvailable(ui->setPassword0->text(), !ui->passwordInfo->isVisible());
-
+    ui->setDeviceName->setText("");
+    ui->setPasswordOld->setText("");
     ui->setPassword0->setText("");
     ui->setPassword1->setText("");
 }
@@ -86,7 +90,7 @@ void ModalView::showOrHide(bool state)
     emit modalViewWillShowHide(false);
 }
 
-void ModalView::showSetPasswordInfo(bool showCleanInfo)
+void ModalView::showSetPasswordInfo(bool newWallet)
 {
 
     ui->abortButton->setVisible(false);
@@ -95,13 +99,25 @@ void ModalView::showSetPasswordInfo(bool showCleanInfo)
     ui->showDetailsButton->setVisible(false);
     ui->okButton->setVisible(false);
     ui->setPasswordWidget->setVisible(true);
-    ui->passwordInfo->setVisible(showCleanInfo);
-    ui->cancelSetPassword->setVisible(!showCleanInfo);
+    ui->passwordWarning->setText("");
+    if (newWallet) {
+        ui->setDeviceName->setVisible(true);
+        ui->cancelSetPassword->setVisible(false);
+        ui->setPasswordOld->setVisible(false);
+        ui->setPassword0->setPlaceholderText("Password");
+        ui->setDeviceName->setFocus();
+    } else {
+        ui->setDeviceName->setVisible(false);
+        ui->cancelSetPassword->setVisible(true);
+        ui->setPasswordOld->setVisible(true);
+        ui->setPassword0->setPlaceholderText("New password");
+        ui->setPasswordOld->setFocus();
+    }
+    
     ui->modalInfoLabel->setVisible(false);
     ui->modalInfoLabelLA->setVisible(false);
     ui->modalInfoLabel->setText("");
     ui->modalInfoLabelLA->setText("");
-    ui->setPassword0->setFocus();
     ui->modalIcon->setIcon(QIcon());
 
     ui->setPassword->setEnabled(false);
@@ -305,14 +321,31 @@ void ModalView::updateIcon(const QIcon& icon)
     ui->modalIcon->setIcon(icon);
 }
 
-void ModalView::keyPressEvent(QKeyEvent* event){
+void ModalView::keyPressEvent(QKeyEvent* event)
+{
     if ((event->key()==Qt::Key_Return) && visible && ui->okButton->isVisible())
         showOrHide(false);
-
 }
 
-void ModalView::passwordCheck(const QString& password0){
-    if (ui->setPassword0->text().size() < 4)
+void ModalView::passwordCheck(const QString& password0)
+{    
+    if (ui->setDeviceName->isVisible())
+    {
+        if (ui->setDeviceName->text().size() < 1)
+        {
+            ui->passwordWarning->setText(tr("Enter a name"));
+            ui->setPassword->setEnabled(false);
+            return;
+        }
+        QRegExp nameMatcher("^[0-9A-Z-_]{1,64}$", Qt::CaseInsensitive);
+        if (!nameMatcher.exactMatch(ui->setDeviceName->text()))
+        {
+            ui->passwordWarning->setText(tr("Name has invalid character"));
+            ui->setPassword->setEnabled(false);
+            return;
+        }
+    }
+    if (ui->setPassword0->text().size() < 4 && ui->setPassword0->text().size() > 0)
     {
         ui->passwordWarning->setText(tr("Password too short"));
         ui->setPassword->setEnabled(false);

--- a/src/qt/modalview.h
+++ b/src/qt/modalview.h
@@ -22,13 +22,13 @@ public:
     Ui::ModalView *ui;
 
 signals:
-    void newPasswordAvailable(const QString&, bool);
+    void newPasswordAvailable(const QString&, const QString&, bool);
     void signingShouldProceed(const QString&, void *, const UniValue&, int);
     void modalViewWillShowHide(bool);
 
 public slots:
     void showOrHide(bool state = false);
-    void showSetPasswordInfo(bool showCleanInfo = false);
+    void showSetPasswordInfo(bool newWallet = false);
     void showModalInfo(const QString &info, int helpType);
     void showTransactionVerification(bool twoFAlocked, bool showQRSqeuence = false);
     void setPasswordProvided();

--- a/src/qt/ui/modalview.ui
+++ b/src/qt/ui/modalview.ui
@@ -95,7 +95,7 @@
       <x>-1</x>
       <y>-1</y>
       <width>401</width>
-      <height>359</height>
+      <height>442</height>
      </rect>
     </property>
     <layout class="QVBoxLayout" name="verticalLayout_6">
@@ -103,30 +103,71 @@
       <number>20</number>
      </property>
      <item>
-      <widget class="QLabel" name="passwordInfo">
-       <property name="styleSheet">
-        <string notr="true">color:white;</string>
-       </property>
-       <property name="text">
-        <string>This Digtial Bitbox is new and needs a password.</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="setPasswordTitle">
+      <widget class="QLineEdit" name="setDeviceName">
        <property name="font">
         <font>
          <pointsize>20</pointsize>
         </font>
        </property>
        <property name="styleSheet">
-        <string notr="true">color:white;
-                          </string>
+        <string notr="true">background:white;
+                              border:0px;
+                              border-radius: 5px;
+                              padding:4px;</string>
        </property>
        <property name="text">
-        <string>Choose a password</string>
+        <string/>
+       </property>
+       <property name="maxLength">
+        <number>64</number>
+       </property>
+       <property name="echoMode">
+        <enum>QLineEdit::Normal</enum>
+       </property>
+       <property name="placeholderText">
+        <string>New wallet name</string>
        </property>
       </widget>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="setPasswordOld">
+       <property name="font">
+        <font>
+         <pointsize>20</pointsize>
+        </font>
+       </property>
+       <property name="styleSheet">
+        <string notr="true">background:white;
+                              border:0px;
+                              border-radius: 5px;
+                              padding:4px;</string>
+       </property>
+       <property name="maxLength">
+        <number>64</number>
+       </property>
+       <property name="echoMode">
+        <enum>QLineEdit::Password</enum>
+       </property>
+       <property name="placeholderText">
+        <string>Old password</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="verticalSpacer">
+       <property name="orientation">
+        <enum>Qt::Vertical</enum>
+       </property>
+       <property name="sizeType">
+        <enum>QSizePolicy::Fixed</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>20</width>
+         <height>10</height>
+        </size>
+       </property>
+      </spacer>
      </item>
      <item>
       <widget class="QLineEdit" name="setPassword0">
@@ -141,11 +182,14 @@
                               border-radius: 5px;
                               padding:4px;</string>
        </property>
+       <property name="maxLength">
+        <number>64</number>
+       </property>
        <property name="echoMode">
         <enum>QLineEdit::Password</enum>
        </property>
        <property name="placeholderText">
-        <string>Password</string>
+        <string>New password</string>
        </property>
       </widget>
      </item>
@@ -161,6 +205,9 @@
                               border:0px;
                               border-radius: 5px;
                               padding:4px;</string>
+       </property>
+       <property name="maxLength">
+        <number>64</number>
        </property>
        <property name="echoMode">
         <enum>QLineEdit::Password</enum>
@@ -200,7 +247,7 @@
                               padding:4px;</string>
          </property>
          <property name="text">
-          <string>Set Password</string>
+          <string>Submit</string>
          </property>
          <property name="flat">
           <bool>false</bool>

--- a/src/qt/ui/overview.ui
+++ b/src/qt/ui/overview.ui
@@ -842,7 +842,7 @@ background-color: rgba(240,240,240,255);
                   <string notr="true">color: #888888</string>
                  </property>
                  <property name="text">
-                  <string>Version</string>
+                  <string>App Version</string>
                  </property>
                  <property name="alignment">
                   <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
@@ -896,6 +896,45 @@ background-color: rgba(240,240,240,255);
                 <number>5</number>
                </property>
                <item>
+                <widget class="QLabel" name="deviceNameKeyLabel">
+                 <property name="font">
+                  <font>
+                   <weight>75</weight>
+                   <bold>true</bold>
+                  </font>
+                 </property>
+                 <property name="styleSheet">
+                  <string notr="true">color: #888888</string>
+                 </property>
+                 <property name="text">
+                  <string>Device Name</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="ClickableLabel" name="deviceNameLabel" native="true">
+                 <property name="toolTip">
+                  <string>Click to set a new device name</string>
+                 </property>
+                 <property name="text" stdset="0">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </item>
+             <item>
+              <layout class="QHBoxLayout" name="horizontalLayout3">
+               <property name="topMargin">
+                <number>0</number>
+               </property>
+               <property name="bottomMargin">
+                <number>5</number>
+               </property>
+               <item>
                 <widget class="QLabel" name="versionKeyLabel">
                  <property name="font">
                   <font>
@@ -918,48 +957,6 @@ background-color: rgba(240,240,240,255);
                 <widget class="QLabel" name="versionLabel">
                  <property name="text">
                   <string>TextLabel</string>
-                 </property>
-                 <property name="alignment">
-                  <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-                 </property>
-                </widget>
-               </item>
-              </layout>
-             </item>
-             <item>
-              <layout class="QHBoxLayout" name="horizontalLayout3">
-               <property name="topMargin">
-                <number>0</number>
-               </property>
-               <property name="bottomMargin">
-                <number>5</number>
-               </property>
-               <item>
-                <widget class="QLabel" name="deviceNameKeyLabel">
-                 <property name="font">
-                  <font>
-                   <weight>75</weight>
-                   <bold>true</bold>
-                  </font>
-                 </property>
-                 <property name="styleSheet">
-                  <string notr="true">color: #888888</string>
-                 </property>
-                 <property name="text">
-                  <string>Device Name</string>
-                 </property>
-                 <property name="alignment">
-                  <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="ClickableLabel" name="deviceNameLabel">
-                 <property name="text">
-                  <string/>
-                 </property>
-                 <property name="toolTip">
-                     <string>Click to set a new device name</string>
                  </property>
                  <property name="alignment">
                   <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>


### PR DESCRIPTION
- set device name when creating a new wallet
- require the old pw when updating to a new pw

note that some of the info text was removed as i felt it was now redundant to the placeholder text
