### PR TITLE
Update text; use tooltips

### DIFF
--- a/src/qt/dbb_gui.cpp
+++ b/src/qt/dbb_gui.cpp
@@ -346,6 +346,11 @@ DBBDaemonGui::DBBDaemonGui(const QString& uri, QWidget* parent) : QMainWindow(pa
         verificationActivityAnimation->setLoopCount(8);
     }
 
+    // Set the tx fee tooltips
+    this->ui->feeLevel->setItemData(0, "Confirms as soon as possible", Qt::ToolTipRole);
+    this->ui->feeLevel->setItemData(1, "Confirms ~30 minutes", Qt::ToolTipRole);
+    this->ui->feeLevel->setItemData(2, "Confirms ~1 hour", Qt::ToolTipRole);
+    this->ui->feeLevel->setItemData(3, "Confirms ~4 hours", Qt::ToolTipRole);
 
     connect(this->ui->overviewButton, SIGNAL(clicked()), this, SLOT(mainOverviewButtonClicked()));
     connect(this->ui->multisigButton, SIGNAL(clicked()), this, SLOT(mainMultisigButtonClicked()));

--- a/src/qt/ui/overview.ui
+++ b/src/qt/ui/overview.ui
@@ -384,7 +384,7 @@ background-color: rgba(240,240,240,255);
             </size>
            </property>
            <property name="text">
-            <string></string>
+            <string/>
            </property>
           </widget>
          </item>
@@ -1166,7 +1166,7 @@ background-color: rgba(240,240,240,255);
             <bool>false</bool>
            </property>
            <property name="placeholderText">
-            <string>    To Address</string>
+            <string> To Address</string>
            </property>
           </widget>
          </item>
@@ -1210,7 +1210,7 @@ background-color: rgba(240,240,240,255);
             <bool>false</bool>
            </property>
            <property name="placeholderText">
-            <string>    Amount</string>
+            <string> Amount BTC</string>
            </property>
           </widget>
          </item>
@@ -1221,22 +1221,22 @@ background-color: rgba(240,240,240,255);
            </property>
            <item>
             <property name="text">
-             <string>priority (~next block)</string>
+             <string>Priority</string>
             </property>
            </item>
            <item>
             <property name="text">
-             <string>normal (~2 blocks)</string>
+             <string>Standard</string>
             </property>
            </item>
            <item>
             <property name="text">
-             <string>economy (~6 blocks)</string>
+             <string>Economy</string>
             </property>
            </item>
            <item>
             <property name="text">
-             <string>supereconomy (~24 blocks)</string>
+             <string>Budget</string>
             </property>
            </item>
           </widget>


### PR DESCRIPTION
Ability to select fee level is great.

This PR has minor text edits. I moved the block-time into tooltips, and used units of time instead of nBlocks. Also added 'BTC' to the 'Amount' placeholder text since the BTC spinbox indicating units is gone.